### PR TITLE
feat: dismiss popup when tapping first character of selection

### DIFF
--- a/Features/Reader/ReaderWebView/reader.js
+++ b/Features/Reader/ReaderWebView/reader.js
@@ -338,6 +338,14 @@ window.hoshiReader = {
             return null;
         }
         
+        // Dismiss popup if tapping on the first character of the current selection
+        if (this.selection &&
+            hit.node === this.selection.startNode &&
+            hit.offset === this.selection.startOffset) {
+            this.clearHighlight();
+            return null;
+        }
+
         this.clearHighlight();
         
         const container = this.findParagraph(hit.node) || document.body;


### PR DESCRIPTION
### Summary

- When the lookup popup is open, tapping the first character of the current selection now closes the popup and clears the highlight. Tapping any other character in the highlighted word still starts a new selection (e.g. to look up a suffix like "合う " inside "話し合う"), so sub-word lookups are unchanged. This was initially brought up in [this](https://discord.com/channels/617136488840429598/1465409869971718416/1469305585747890288) thread in TheMoeWay Discord server.

### Testing

- Tap a word → popup opens. Tap the first character again → popup closes.
- Tap a word → popup opens. Tap another character in the same word → new selection/lookup (e.g. suffix).
- Tap outside text → popup still closes as before.


https://github.com/user-attachments/assets/99ff3d03-7b74-44f2-b22f-5405f08a5054

