### PR TITLE
Align frequency harmonic rank calculation

### DIFF
--- a/Features/Popup/popup.js
+++ b/Features/Popup/popup.js
@@ -448,6 +448,8 @@ function constructPitchCategories(pitches, reading, definitionTags) {
     return categories.join(',');
 }
 
+// Yomitan reference:
+// https://github.com/yomidevs/yomitan/blob/c0abb9e98a15aeb6b6f8f6e2d91fe5e54240b54a/ext/js/data/anki-note-data-creator.js#L177-L221
 function getFrequencyHarmonicRank(frequencies) {
     if (!frequencies || frequencies.length === 0) {
         return DEFAULT_HARMONIC_RANK;


### PR DESCRIPTION
Summary:
  - Deduplicate frequencies by dictionary and only use the first entry.
  - Prefer numeric prefix from displayValue, otherwise fall back to value.
  - Use Math.floor for the harmonic mean.

Correct (yomitan):

<img width="444" height="508" alt="8133f970126a6b38f509b5fed72d30d8" src="https://github.com/user-attachments/assets/50bd3973-72b5-4dc0-8df6-f8d5f13b7938" />

Incorrect (current behavior):

<img width="435" height="569" alt="5edf3436f2755f22f15caab50bbe8653" src="https://github.com/user-attachments/assets/248eb3b1-b88c-488b-bd68-34a431416d6e" />

This PR will fix this problem.

Btw: すいちゃんは今日もかわいい！

![f15e6f2a3659de7906253f2c0bb9de72](https://github.com/user-attachments/assets/e487293e-36e8-4fd9-ba49-69b2861596f9)
