### PR TITLE
feat: add line height configuration to user settings

### DIFF
--- a/Core/UserConfig.swift
+++ b/Core/UserConfig.swift
@@ -87,16 +87,16 @@ class UserConfig {
         didSet { UserDefaults.standard.set(verticalWriting, forKey: "verticalWriting") }
     }
     
+    var selectedFont: String {
+        didSet { UserDefaults.standard.set(selectedFont, forKey: "selectedFont") }
+    }
+    
     var fontSize: Int {
         didSet { UserDefaults.standard.set(fontSize, forKey: "fontSize") }
     }
-
-    var lineHeight: Double {
-        didSet { UserDefaults.standard.set(lineHeight, forKey: "lineHeight") }
-    }
     
-    var selectedFont: String {
-        didSet { UserDefaults.standard.set(selectedFont, forKey: "selectedFont") }
+    var readerHideFurigana: Bool {
+        didSet { UserDefaults.standard.set(readerHideFurigana, forKey: "readerHideFurigana") }
     }
     
     var horizontalPadding: Int {
@@ -107,8 +107,16 @@ class UserConfig {
         didSet { UserDefaults.standard.set(verticalPadding, forKey: "verticalPadding") }
     }
     
-    var readerHideFurigana: Bool {
-        didSet { UserDefaults.standard.set(readerHideFurigana, forKey: "readerHideFurigana") }
+    var layoutAdvanced: Bool {
+        didSet { UserDefaults.standard.set(layoutAdvanced, forKey: "layoutAdvanced") }
+    }
+    
+    var lineHeight: Double {
+        didSet { UserDefaults.standard.set(lineHeight, forKey: "lineHeight") }
+    }
+    
+    var characterSpacing: Double {
+        didSet { UserDefaults.standard.set(characterSpacing, forKey: "characterSpacing") }
     }
     
     var readerShowTitle: Bool {
@@ -234,13 +242,15 @@ class UserConfig {
         self.customTextColor = UserConfig.loadColor(key: "customTextColor") ?? Color(.sRGB, red: 0, green: 0, blue: 0)
         
         self.verticalWriting = defaults.object(forKey: "verticalWriting") as? Bool ?? true
-        self.fontSize = defaults.object(forKey: "fontSize") as? Int ?? 22
-        self.lineHeight = defaults.object(forKey: "lineHeight") as? Double ?? 1.65
         self.selectedFont = defaults.string(forKey: "selectedFont") ?? "Hiragino Mincho ProN"
+        self.fontSize = defaults.object(forKey: "fontSize") as? Int ?? 22
+        self.readerHideFurigana = defaults.object(forKey: "readerHideFurigana") as? Bool ?? false
         
         self.horizontalPadding = defaults.object(forKey: "horizontalPadding") as? Int ?? 10
         self.verticalPadding = defaults.object(forKey: "verticalPadding") as? Int ?? 0
-        self.readerHideFurigana = defaults.object(forKey: "readerHideFurigana") as? Bool ?? false
+        self.layoutAdvanced = defaults.object(forKey: "layoutAdvanced") as? Bool ?? false
+        self.lineHeight = defaults.object(forKey: "lineHeight") as? Double ?? 1.65
+        self.characterSpacing = defaults.object(forKey: "characterSpacing") as? Double ?? 0
         
         self.readerShowTitle = defaults.object(forKey: "readerShowTitle") as? Bool ?? true
         self.readerShowCharacters = defaults.object(forKey: "readerShowCharacters") as? Bool ?? true

--- a/Features/Reader/ReaderView/ReaderView.swift
+++ b/Features/Reader/ReaderView/ReaderView.swift
@@ -12,13 +12,15 @@ import EPUBKit
 struct WebViewState: Hashable {
     var verticalWriting: Bool
     var fontSize: Int
-    var lineHeight: Double
-    var horizontalPadding: Int
-    var verticalPadding: Int
-    var size: CGSize
-    var textColor: Color
     var selectedFont: String
     var hideFurigana: Bool
+    var horizontalPadding: Int
+    var verticalPadding: Int
+    var layoutAdvanced: Bool
+    var lineHeight: Double
+    var characterSpacing: Double
+    var size: CGSize
+    var textColor: Color
 }
 
 struct ReaderLoader: View {
@@ -123,13 +125,15 @@ struct ReaderView: View {
                     .id(WebViewState(
                         verticalWriting: userConfig.verticalWriting,
                         fontSize: userConfig.fontSize,
-                        lineHeight: userConfig.lineHeight,
+                        selectedFont: userConfig.selectedFont,
+                        hideFurigana: userConfig.readerHideFurigana,
                         horizontalPadding: userConfig.horizontalPadding,
                         verticalPadding: userConfig.verticalPadding,
+                        layoutAdvanced: userConfig.layoutAdvanced,
+                        lineHeight: userConfig.lineHeight,
+                        characterSpacing: userConfig.characterSpacing,
                         size: geometry.size,
                         textColor: readerTextColor,
-                        selectedFont: userConfig.selectedFont,
-                        hideFurigana: userConfig.readerHideFurigana
                     ))
                     
                     ForEach(Array(viewModel.popups.enumerated()), id: \.element.id) { index, _ in

--- a/Features/Reader/ReaderWebView/ReaderWebView.swift
+++ b/Features/Reader/ReaderWebView/ReaderWebView.swift
@@ -227,6 +227,13 @@ struct ReaderWebView: UIViewRepresentable {
                 }
             }
             
+            var textSpacingCss = ""
+            if parent.userConfig.layoutAdvanced {
+                textSpacingCss = """
+                line-height: \(parent.userConfig.lineHeight) !important;
+                letter-spacing: \((parent.userConfig.characterSpacing / 100.0))em !important;
+                """
+            }
             
             let css = """
             \(fontFaceCss)
@@ -240,7 +247,7 @@ struct ReaderWebView: UIViewRepresentable {
                 writing-mode: \(writingMode) !important;
                 font-family: \(parent.userConfig.selectedFont), serif !important;
                 font-size: \(parent.userConfig.fontSize)px !important;
-                line-height: \(parent.userConfig.lineHeight) !important;
+                \(textSpacingCss)
                 box-sizing: border-box !important;
                 column-width: var(--page-height, 100vh) !important;
                 column-height: var(--page-width, 100vw) !important;

--- a/Features/Settings/AppearanceView.swift
+++ b/Features/Settings/AppearanceView.swift
@@ -39,7 +39,7 @@ struct AppearanceView: View {
                     }
                 }
                 
-                Section("Reader Layout") {
+                Section("Text") {
                     if #available(iOS 26, *) {
                         HStack {
                             Text("Text Orientation")
@@ -110,16 +110,11 @@ struct AppearanceView: View {
                         Stepper("", value: $userConfig.fontSize, in: 16...40)
                             .labelsHidden()
                     }
-
-                    HStack {
-                        Text("Line Height")
-                        Spacer()
-                        Text("\(userConfig.lineHeight, specifier: "%.2f")")
-                            .fontWeight(.semibold)
-                        Stepper("", value: $userConfig.lineHeight, in: 1.0...2.5, step: 0.05)
-                            .labelsHidden()
-                    }
                     
+                    Toggle("Hide Furigana", isOn: $userConfig.readerHideFurigana)
+                }
+                
+                Section("Layout") {
                     HStack {
                         Text("Horizontal Padding")
                         Spacer()
@@ -138,10 +133,30 @@ struct AppearanceView: View {
                             .labelsHidden()
                     }
                     
-                    Toggle("Hide Furigana", isOn: $userConfig.readerHideFurigana)
+                    Toggle("Advanced", isOn: $userConfig.layoutAdvanced)
+                    if userConfig.layoutAdvanced {
+                        VStack {
+                            HStack {
+                                Text("Line Height")
+                                Spacer()
+                                Text("\(userConfig.lineHeight, specifier: "%.2f")")
+                                    .fontWeight(.semibold)
+                            }
+                            Slider(value: $userConfig.lineHeight, in: 1.0...2.5, step: 0.05)
+                        }
+                        VStack {
+                            HStack {
+                                Text("Character Spacing")
+                                Spacer()
+                                Text("\(Int(userConfig.characterSpacing))%")
+                                    .fontWeight(.semibold)
+                            }
+                            Slider(value: $userConfig.characterSpacing, in: -10...10, step: 1)
+                        }
+                    }
                 }
                 
-                Section("Reader Display") {
+                Section("Display") {
                     Toggle("Show Title", isOn: $userConfig.readerShowTitle)
                     Toggle("Show Character Count", isOn: $userConfig.readerShowCharacters)
                     Toggle("Show Percentage", isOn: $userConfig.readerShowPercentage)
@@ -186,7 +201,7 @@ struct AppearanceView: View {
                         ), in: 100...350, step: 10)
                     }
                     
-                    Toggle("Full width Popup", isOn: Bindable(userConfig).popupFullWidth)
+                    Toggle("Full-width", isOn: Bindable(userConfig).popupFullWidth)
                     
                     Toggle("Swipe to Dismiss", isOn: Bindable(userConfig).popupSwipeToDismiss)
                     if userConfig.popupSwipeToDismiss {


### PR DESCRIPTION
# Summary
Added a customizable line height setting to the reader, allowing users to adjust text line spacing according to their reading preferences.

# Technical Details
- Line height range: 1.0 - 2.5
- Adjustment step: 0.05
- Default value: 1.65